### PR TITLE
Add manual version bump GitHub Action and update install docs

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,62 @@
+name: Version Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute new version
+        id: version
+        run: |
+          current=$(grep -m1 '^version' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          IFS='.' read -r major minor patch <<< "$current"
+
+          case "${{ inputs.bump }}" in
+            major) major=$((major + 1)); minor=0; patch=0 ;;
+            minor) minor=$((minor + 1)); patch=0 ;;
+            patch) patch=$((patch + 1)) ;;
+          esac
+
+          new="${major}.${minor}.${patch}"
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "new=$new" >> "$GITHUB_OUTPUT"
+          echo "Bumping ${{ inputs.bump }}: $current -> $new"
+
+      - name: Update pyproject.toml
+        run: sed -i 's/^version = ".*"/version = "${{ steps.version.outputs.new }}"/' pyproject.toml
+
+      - name: Update src/refex/__init__.py
+        run: sed -i 's/^__version__ = ".*"/__version__ = "${{ steps.version.outputs.new }}"/' src/refex/__init__.py
+
+      - name: Commit and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml src/refex/__init__.py
+          git commit -m "Bump version to ${{ steps.version.outputs.new }}"
+          git tag "v${{ steps.version.outputs.new }}"
+          git push origin HEAD --tags
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.version.outputs.new }}" \
+            --title "v${{ steps.version.outputs.new }}" \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@ Supported countries:
 
 ## Install
 
-```
-# from git
-pip install git+https://github.com/openlegaldata/legal-reference-extraction.git#egg=legal-reference-extraction
+```bash
+# latest from git
+pip install git+https://github.com/openlegaldata/legal-reference-extraction.git
 
-# Local dev
+# specific version (using git tag)
+pip install git+https://github.com/openlegaldata/legal-reference-extraction.git@v0.3.0
+
+# local dev
 make install
 ```
 


### PR DESCRIPTION
Add a workflow_dispatch action that bumps major/minor/patch version in pyproject.toml and src/refex/__init__.py, commits, tags, and creates a GitHub release. Update README install section with versioned install example.