### PR TITLE
Support full law name references (fixes #9)

### DIFF
--- a/tests/test_law_extractor.py
+++ b/tests/test_law_extractor.py
@@ -512,6 +512,33 @@ def test_extract27(law_extractor):
     )
 
 
+def test_extract_full_law_name(law_extractor):
+    """Full law name references like '§ 8 des Außensteuergesetzes' (issue #9)."""
+    assert_refs(
+        law_extractor,
+        [
+            {
+                "content": "unter § 8 Absatz 1 Nummern 1 bis 6 des deutschen Außensteuergesetzes fallenden Tätigkeiten",
+                "refs": [
+                    Ref(ref_type=RefType.LAW, book="außensteuergesetz", section="8"),
+                ],
+            },
+            {
+                "content": "gemäß § 40 des Verwaltungsverfahrensgesetzes ist der Verwaltungsakt nichtig",
+                "refs": [
+                    Ref(ref_type=RefType.LAW, book="verwaltungsverfahrensgesetz", section="40"),
+                ],
+            },
+            {
+                "content": "nach § 343 der Zivilprozessordnung kann das Gericht entscheiden",
+                "refs": [
+                    Ref(ref_type=RefType.LAW, book="zivilprozessordnung", section="343"),
+                ],
+            },
+        ],
+    )
+
+
 def test_citation_styles(law_extractor):
     with open(os.path.join(RESOURCE_DIR, "citation_styles.txt")) as f:
         x = DivideAndConquerLawRefExtractorMixin()


### PR DESCRIPTION
## Summary

- Add a new matching phase in the DnC law extractor for references that use full German law names instead of abbreviations (e.g. `§ 8 Absatz 1 Nummern 1 bis 6 des deutschen Außensteuergesetzes`)
- Handles genitive suffixes (`-gesetzes` → `-gesetz`, `-gesetzbuches` → `-gesetzbuch`) and feminine articles (`der Zivilprozessordnung`)
- Handles optional adjectives between the article and the law name (e.g. `des deutschen ...`)
- The book value is the full name normalized to lowercase with genitive suffix stripped (e.g. `außensteuergesetz`)

Closes #9

## Supported patterns

| Input | Extracted book | Section |
|---|---|---|
| `§ 8 ... des deutschen Außensteuergesetzes` | `außensteuergesetz` | `8` |
| `§ 40 des Verwaltungsverfahrensgesetzes` | `verwaltungsverfahrensgesetz` | `40` |
| `§ 343 der Zivilprozessordnung` | `zivilprozessordnung` | `343` |

## Test plan

- [x] New test `test_extract_full_law_name` covers the exact input from issue #9 plus two additional patterns
- [x] All 89 existing tests still pass (4 skipped, unchanged)
- [x] Lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)