### PR TITLE
fix(orchestrator): keep co-located enumeration citations

### DIFF
--- a/src/refex/orchestrator.py
+++ b/src/refex/orchestrator.py
@@ -77,10 +77,14 @@ class CitationExtractor:
 
 
 def _resolve_overlaps(citations: list[Citation]) -> list[Citation]:
-    """Remove overlapping citations, keeping the one with higher confidence.
+    """Remove *proper* overlapping citations, keeping the higher-confidence one.
 
-    When two citations overlap, the one with higher ``confidence`` wins.
-    On ties, the longer span wins.  On further ties, the first one wins.
+    Two citations with **identical** spans are treated as co-located rather
+    than overlapping: enumeration markers like "§§ 500a, 500b BGB" emit one
+    LawCitation per section, all sharing the same marker span, and both
+    must survive. Only spans that partially overlap (different start/end)
+    trigger dedupe; in that case higher ``confidence`` wins, ties broken
+    by longer span, then by first occurrence.
     """
     if not citations:
         return []
@@ -90,16 +94,24 @@ def _resolve_overlaps(citations: list[Citation]) -> list[Citation]:
 
     result: list[Citation] = []
     last_end = -1
+    last_start = -1
 
     for cit in sorted_cits:
         if cit.span.start >= last_end:
+            # No overlap with the previous accepted citation.
             result.append(cit)
+            last_start = cit.span.start
             last_end = cit.span.end
+        elif cit.span.start == last_start and cit.span.end == last_end:
+            # Identical span — co-located citation from the same marker
+            # (e.g. enumeration "§§ 3, 4 BGB" yields one cite per section).
+            result.append(cit)
         else:
-            # Overlap: check if this citation should replace the last one
+            # Proper overlap: keep the higher-confidence citation.
             prev = result[-1]
             if cit.confidence > prev.confidence:
                 result[-1] = cit
+                last_start = cit.span.start
                 last_end = cit.span.end
 
     return result

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -103,9 +103,31 @@ class TestCitationExtractor:
         text = "§ 433 BGB und § 812 BGB"
         ext = CitationExtractor()
         result = ext.extract(text)
+        # Two disjoint cites — neither equals the other's span.
         sorted_cits = sorted(result.citations, key=lambda c: c.span.start)
         for i in range(len(sorted_cits) - 1):
-            assert sorted_cits[i].span.end <= sorted_cits[i + 1].span.start
+            a, b = sorted_cits[i], sorted_cits[i + 1]
+            assert a.span.end <= b.span.start or (
+                a.span.start == b.span.start and a.span.end == b.span.end
+            )
+
+    def test_enumeration_keeps_all_sections(self):
+        """Co-located cites from one enumeration marker must all survive.
+
+        ``RegexLawExtractor`` emits one ``LawCitation`` per section in
+        "§§ 500a, 500b BGB", all sharing the same marker span. The
+        orchestrator's ``_resolve_overlaps`` pass historically treated
+        identical spans as overlaps and dropped all but one — this test
+        pins the corrected behaviour: identical spans are co-located,
+        not overlapping.
+        """
+        text = "Laut §§ 3, 4 BGB gilt dies."
+        ext = CitationExtractor()
+        result = ext.extract(text)
+        law_cits = [c for c in result.citations if isinstance(c, LawCitation)]
+        sections = {c.number for c in law_cits}
+        assert "3" in sections, sections
+        assert "4" in sections, sections
 
 
 class TestResolveOverlaps:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -107,9 +107,7 @@ class TestCitationExtractor:
         sorted_cits = sorted(result.citations, key=lambda c: c.span.start)
         for i in range(len(sorted_cits) - 1):
             a, b = sorted_cits[i], sorted_cits[i + 1]
-            assert a.span.end <= b.span.start or (
-                a.span.start == b.span.start and a.span.end == b.span.end
-            )
+            assert a.span.end <= b.span.start or (a.span.start == b.span.start and a.span.end == b.span.end)
 
     def test_enumeration_keeps_all_sections(self):
         """Co-located cites from one enumeration marker must all survive.


### PR DESCRIPTION
## Summary

`_resolve_overlaps` was treating two citations with **identical** spans as overlaps and dropping all but one. Enumeration markers like \`§§ 500a, 500b BGB\` emit one \`LawCitation\` per section — all sharing the marker's span — and the merge pass silently discarded the secondary sections.

Treat identical-span pairs as co-located rather than overlapping; partially-overlapping spans (different start/end) still trigger confidence-based dedupe as before.

## How it surfaced

Caught downstream while migrating [OLDP](https://github.com/openlegaldata/oldp) from the legacy \`RefExtractor\` to \`CitationExtractor\`. A fixture case (LG München I) dropped from **33 references → 26** because compound enumerations were collapsing to their first section:

| Marker | Legacy refs | Pre-fix | Post-fix |
|---|---|---|---|
| \`§§ 500a, 500b BGB\` | 2 | 1 | 2 |
| \`§§ 1, 2 Abs. 2, 3, 700 Abs. 1 Nr. 1 BGB\` | 4 | 1 | 4 |
| \`§§ 708 Nr. 11, 711, 709 S. 2 ZPO\` | 3 | 1 | 3 |

The underlying \`RegexLawExtractor.extract\` already emitted all sections correctly — \`tests/test_orchestrator.py::TestRegexLawExtractor::test_multi_ref\` covers that. The bug only manifested when going through the orchestrator.

## Changes

- \`_resolve_overlaps\`: track \`last_start\` alongside \`last_end\`; when the next citation has \`(start, end)\` identical to the previous one, append it instead of treating it as an overlap to dedupe.
- New regression test \`TestCitationExtractor::test_enumeration_keeps_all_sections\` exercises \`§§ 3, 4 BGB\` end-to-end through \`CitationExtractor.extract\` and asserts both sections survive.
- Adjusted \`test_no_overlap_in_output\` so the assertion still holds for both disjoint cites and (legitimately) co-located cites.

## Test plan

- [x] \`pytest tests/test_orchestrator.py\` — 22 passed (added 1)
- [x] Full suite \`pytest\` — 348 passed, 4 deselected, no new warnings
- [x] Verified downstream: oldp's case-1888 fixture now emits 33 refs again

🤖 Generated with [Claude Code](https://claude.com/claude-code)