### PR TITLE
fix(law): extract citations that end the document

### DIFF
--- a/src/refex/extractors/law.py
+++ b/src/refex/extractors/law.py
@@ -202,7 +202,9 @@ class DivideAndConquerLawRefExtractorMixin:
         sect_space = r"\s"
         bp = self._book_ref_regex
         wd = self._default_word_delimiter
-        bla = "(?=" + wd + ")"
+        # End-of-string is a valid terminator: a citation that ends the
+        # document has no delimiter after the book code but should still match.
+        bla = "(?:(?=" + wd + ")|$)"
         ac = r"([0-9]{1,5}|\.|[a-z]|[IXV]{1,3}|Abs\.|Abs|Satz|Halbsatz|S\.|Nr|Nr\.|Alt|Alt\.|und|bis|,|;|\s)*"
         sp = r"(?P<sect>([0-9]+)(\s?[a-z]?))"
         art_sign = r"Art(?:ikel|\.?)"
@@ -303,7 +305,10 @@ class DivideAndConquerLawRefExtractorMixin:
         # Use \s for the space after § to handle both regular and non-breaking spaces
         sect_space = r"\s"
 
-        book_look_ahead = "(?=" + word_delimiter + ")"
+        # End-of-string is a valid terminator: a citation that ends the
+        # document ("Komplexe Zitate gibt es auch §§ 3, 3b AsylG") has no
+        # delimiter after the book code, but should still match.
+        book_look_ahead = "(?:(?=" + word_delimiter + ")|$)"
         book_pattern = self._book_ref_regex
 
         any_content = r"([0-9]{1,5}|\.|[a-z]|[IXV]{1,3}|Abs\.|Abs|Satz|Halbsatz|S\.|Nr|Nr\.|Alt|Alt\.|und|bis|,|;|\s)*"  # noqa: E501

--- a/tests/test_law_extractor.py
+++ b/tests/test_law_extractor.py
@@ -36,6 +36,23 @@ def test_extract(law_extractor):
     new_content, markers = law_extractor.extract(content_html)
 
 
+def test_extract_at_end_of_string(law_extractor):
+    """A citation that ends the document must still be extracted.
+
+    The book-code lookahead historically required a trailing word
+    delimiter (whitespace, punctuation, or HTML angle bracket), and
+    silently dropped citations at end-of-string. Real-world documents
+    routinely end on a citation — e.g. plain-text projections of HTML
+    where the final ``</p>`` has been stripped — so end-of-string is
+    now a valid terminator alongside the existing delimiters.
+    """
+    text = "Komplexe Zitate gibt es auch §§ 3, 3b AsylG"
+    _, markers = law_extractor.extract(text)
+    sections = [r.section for m in markers for r in m.references]
+    assert "3" in sections, sections
+    assert "3b" in sections, sections
+
+
 def test_with_law_book_context(law_extractor):
     """Book context is used for extracting law references from within law text, where book is not
     explicitly mentioned."""


### PR DESCRIPTION
## Summary

The book-code lookahead in the law-citation regex required a trailing word delimiter (whitespace, punctuation, or HTML angle bracket), so citations at end-of-string silently dropped. Real-world inputs hit this when text ends on a citation:

- A plain-text projection of HTML where the closing `</p>` has been stripped (the HTML normalizer in `refex.document` calls `.strip()` on the final output).
- A snippet that simply ends mid-thought after a book code.

Adds end-of-string (`$`) as a valid terminator alongside the existing word-delimiter set, in both the precompiled (plain-text) and inline-built (HTML) variants of the law-marker patterns.

## Reproduction

```python
from refex.extractors.law import DivideAndConquerLawRefExtractorMixin

ext = DivideAndConquerLawRefExtractorMixin()
ext.law_book_codes = ["AsylG"]

# With trailing punctuation: works
_, markers = ext.extract_law_ref_markers("Komplexe Zitate gibt es auch §§ 3, 3b AsylG.")
# → 1 marker, 2 refs

# Without (end-of-string): pre-fix returns 0 markers
_, markers = ext.extract_law_ref_markers("Komplexe Zitate gibt es auch §§ 3, 3b AsylG")
# → pre-fix: 0 markers, post-fix: 1 marker, 2 refs
```

## How it surfaced

Caught while migrating [OLDP](https://github.com/openlegaldata/oldp) from the legacy `RefExtractor` to `CitationExtractor`. The case-1 fixture (`<p>... §§ 3, 3b AsylG</p>`) emitted 2 markers via the new path instead of the expected 3, because the HTML normalizer's plain-text projection strips trailing whitespace and the `</p>` along with it — leaving the citation flush against EOS.

## Changes

- `_precompile_patterns`: add `$` to the `book_look_ahead` alternation (used by the plain-text path).
- `extract_law_ref_markers`: same change for the HTML-path inline pattern.
- New regression test `test_extract_at_end_of_string` exercises the bare-string case directly.

## Test plan

- [x] `pytest tests/test_law_extractor.py::test_extract_at_end_of_string` — passes
- [x] Full suite `pytest` — 348 passed, 4 deselected (1 added, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)