### PR TITLE
fix(document): treat <td> and <th> as block-level boundaries

### DIFF
--- a/src/refex/document.py
+++ b/src/refex/document.py
@@ -303,6 +303,8 @@ class _HTMLTextExtractor(HTMLParser):
             "h6",
             "li",
             "tr",
+            "td",
+            "th",
             "dt",
             "dd",
             "blockquote",

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -57,6 +57,32 @@ class TestNormalizeHtml:
         assert "§ 154 Abs. 1 VwGO" in result
         assert "<" not in result
 
+    def test_adjacent_table_cells_get_separator(self):
+        """``<td>`` and ``<th>`` are block-level boundaries.
+
+        Table cells contain semantically separate content that must not
+        run together in the plain-text projection. Without a separator
+        between adjacent ``</td><td>`` cells, a citation in cell A that
+        ends with a book code would concatenate with cell B's leading
+        text and the citation regex's word-delimiter lookahead would
+        miss the match. Real-world impact: legal decisions that lay out
+        norm references in a two-column table (``<td>§ 823 BGB</td>``,
+        ``<td>Schadensersatz</td>``) would yield zero citations.
+        """
+        html = (
+            "<table>"
+            "<tr><td>§ 823 BGB</td><td>Schadensersatz</td></tr>"
+            "<tr><th>§ 280 BGB</th><th>Pflichtverletzung</th></tr>"
+            "</table>"
+        )
+        result = normalize(html, fmt="html")
+        # Cell contents are separated, not concatenated.
+        assert "BGBSchadensersatz" not in result
+        assert "BGBPflichtverletzung" not in result
+        # The citations are still findable by downstream extractors.
+        assert "§ 823 BGB" in result
+        assert "§ 280 BGB" in result
+
 
 class TestNormalizeMarkdown:
     def test_strips_headers(self):


### PR DESCRIPTION
## Summary

The HTML normalizer's block-tag set didn't include `td` or `th`, so adjacent table cells concatenated in the plain-text projection. A two-column table laying out norm references —

```html
<table>
  <tr><td>§ 823 BGB</td><td>Schadensersatz aus unerlaubter Handlung</td></tr>
  <tr><td>§ 826 BGB</td><td>Vorsätzliche sittenwidrige Schädigung</td></tr>
</table>
```

— normalised to:

```
§ 823 BGBSchadensersatz aus unerlaubter Handlung
§ 826 BGBVorsätzliche sittenwidrige Schädigung
```

The book-code lookahead in the law-citation regex requires a word delimiter after the code (now also EOS, after #19), so the cited sections sitting at the end of each ``<td>`` silently dropped. Every cell-bound citation in real legal decisions was invisible to extraction.

This is the third in a series of refex fixes caught while migrating [OLDP](https://github.com/openlegaldata/oldp) to the typed CitationExtractor API:

1. #18 — orchestrator dropped co-located enumeration cites
2. #19 — regex didn't match citations at end-of-string
3. **This PR** — table cells weren't block-level boundaries

## Changes

- Add ``td`` and ``th`` to ``_HTMLTextExtractor._block_tags``. The frozenset is shared with the regex-based ``_normalize_html_with_offsets`` so a single edit covers both code paths.
- New regression test ``test_adjacent_table_cells_get_separator`` exercises both cell types and asserts (a) cell contents are no longer concatenated, (b) the citations inside remain findable in the normalised text.

## Behaviour after fix

```
§ 823 BGB

Schadensersatz aus unerlaubter Handlung

§ 826 BGB

Vorsätzliche sittenwidrige Schädigung
```

(Two consecutive ``\n`` between cells get collapsed by the existing whitespace-merging pass; the boundaries are otherwise identical to how a screen reader or accessibility tool treats table cells.)

## Test plan

- [x] ``pytest tests/test_document.py`` — 57 passed (1 added)
- [x] Full suite ``pytest`` — 350 passed, 4 deselected, no regressions
- [x] Verified downstream in oldp: a table-shape regression fixture (mirroring real production case 183007) now extracts all expected ``§ X BGB`` cites instead of zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)