### PR TITLE
feat(benchmarks): fall back to HuggingFace Hub when local data missing

### DIFF
--- a/benchmarks/datasets.py
+++ b/benchmarks/datasets.py
@@ -1,32 +1,46 @@
-"""Load benchmark datasets from configurable paths.
+"""Load benchmark datasets from local paths or the HuggingFace Hub.
 
 The benchmark data is NOT committed to this repo. It lives in a sibling
-project (german-legal-references-benchmark) or any directory you point to.
+project (german-legal-references-benchmark) or on the HuggingFace Hub.
 
-Supports two formats:
+Supports three sources, resolved in order:
 
-1. **HF Arrow dataset** (preferred): A ``DatasetDict`` saved to disk via
-   ``datasets.save_to_disk()``. Has train/validation/test splits with
-   merged document + annotation data per row.
+1. **Explicit local path** via ``--data-dir`` / ``BENCH_DATA_DIR``. Either
+   an HF Arrow ``DatasetDict`` (saved via ``datasets.save_to_disk()``) or
+   a JSONL directory with ``documents.jsonl`` + ``annotations.jsonl``.
 
-2. **JSONL files** (legacy): A flat directory with ``documents.jsonl`` +
-   ``annotations.jsonl``, or split subdirectories (train/dev/test).
+2. **Default local path** at
+   ``../german-legal-references-benchmark/data/benchmark_10k_hf`` (sibling
+   checkout), used when neither ``--data-dir`` nor ``BENCH_DATA_DIR`` is
+   set.
 
-Default data path: ``../german-legal-references-benchmark/data/benchmark_10k_hf``
-Override via: ``BENCH_DATA_DIR`` environment variable or ``--data-dir`` CLI flag.
+3. **HuggingFace Hub fallback**: if no local path resolves, load from
+   the private Hub repo
+   ``openlegaldata/german-legal-references-benchmark`` via
+   ``datasets.load_dataset()``. Override the repo with ``--hf-repo`` or
+   ``BENCH_HF_REPO``.
+
+The Hub fallback requires the ``datasets`` library and a valid HF token
+with access to the (private) dataset.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # Default: sibling project's 10k HF dataset
 _DEFAULT_DATA_DIR = (
     Path(__file__).resolve().parent.parent.parent / "german-legal-references-benchmark" / "data" / "benchmark_10k_hf"
 )
+
+# Default: private HF Hub repo for the German legal references benchmark.
+_DEFAULT_HF_REPO = "openlegaldata/german-legal-references-benchmark"
 
 
 def get_data_dir() -> Path:
@@ -35,6 +49,25 @@ def get_data_dir() -> Path:
     if env:
         return Path(env)
     return _DEFAULT_DATA_DIR
+
+
+def get_hf_repo() -> str:
+    """Resolve the HuggingFace Hub repo id from env or default."""
+    return os.environ.get("BENCH_HF_REPO", _DEFAULT_HF_REPO)
+
+
+def _local_dataset_exists(data_dir: Path) -> bool:
+    """Return True if ``data_dir`` contains a recognisable dataset."""
+    if not data_dir.exists():
+        return False
+    if (data_dir / "dataset_dict.json").exists():
+        return True
+    if (data_dir / "documents.jsonl").exists():
+        return True
+    for sub in ("train", "validation", "test", "dev"):
+        if (data_dir / sub / "documents.jsonl").exists():
+            return True
+    return False
 
 
 @dataclass
@@ -111,27 +144,62 @@ class BenchmarkDataset:
 def load_dataset(
     data_dir: Path | None = None,
     split: str = "test",
+    hf_repo: str | None = None,
 ) -> BenchmarkDataset:
-    """Load a benchmark dataset from HF Arrow format or JSONL.
+    """Load a benchmark dataset from a local path or the HuggingFace Hub.
 
-    Auto-detects format: if a ``dataset_dict.json`` exists, loads as HF
-    dataset; otherwise falls back to JSONL.
+    Resolution order:
+
+    1. If ``data_dir`` (or ``BENCH_DATA_DIR``) points to an existing
+       dataset, load it locally. Auto-detects HF Arrow vs JSONL.
+    2. Otherwise fall back to ``datasets.load_dataset(hf_repo, ...)``
+       against the HuggingFace Hub. ``hf_repo`` defaults to
+       ``BENCH_HF_REPO`` or
+       ``openlegaldata/german-legal-references-benchmark``.
 
     Args:
-        data_dir: Path to the dataset directory. If None, uses the default
-                  resolved via ``get_data_dir()``.
-        split: Which split to load (train/validation/test). Only used for
-               HF datasets and split JSONL directories.
+        data_dir: Path to a local dataset directory. If None, resolves
+                  via ``get_data_dir()``. When the resolved path does
+                  not contain a recognisable dataset the Hub fallback
+                  is used.
+        split: Which split to load (train/validation/test).
+        hf_repo: HuggingFace Hub repo id used for the fallback. If None,
+                 resolves via ``get_hf_repo()``.
 
     Raises:
-        FileNotFoundError: If the data directory or required files don't exist.
+        FileNotFoundError: If neither a local dataset nor the Hub repo
+            can be loaded.
     """
+    explicit_local = data_dir is not None
     if data_dir is None:
         data_dir = get_data_dir()
-
     data_dir = Path(data_dir)
 
-    # Auto-detect format
+    if _local_dataset_exists(data_dir):
+        return _load_local_dataset(data_dir, split)
+
+    # Local path was explicitly given but doesn't exist — surface the
+    # error rather than silently going to the Hub. Callers can pass an
+    # empty path or unset --data-dir to opt into the fallback.
+    if explicit_local:
+        msg = (
+            f"Benchmark data not found at {data_dir} (--data-dir was explicit).\n"
+            f"Either point --data-dir at a valid dataset or omit it to fall back "
+            f"to the HuggingFace Hub repo {hf_repo or get_hf_repo()!r}."
+        )
+        raise FileNotFoundError(msg)
+
+    repo = hf_repo or get_hf_repo()
+    logger.info(
+        "Local dataset not found at %s — falling back to HuggingFace Hub repo %r",
+        data_dir,
+        repo,
+    )
+    return _load_hf_hub_dataset(repo, split)
+
+
+def _load_local_dataset(data_dir: Path, split: str) -> BenchmarkDataset:
+    """Dispatch to the right local loader based on directory contents."""
     if (data_dir / "dataset_dict.json").exists():
         return _load_hf_dataset(data_dir, split)
 
@@ -148,18 +216,20 @@ def load_dataset(
 
     msg = (
         f"Benchmark data not found at {data_dir}\n"
-        f"Set BENCH_DATA_DIR or use --data-dir to point to a dataset directory.\n"
         f"Supported formats: HF Arrow (dataset_dict.json) or JSONL (documents.jsonl)"
     )
     raise FileNotFoundError(msg)
 
 
+def _ensure_hf_cache_env() -> None:
+    """Default HF cache locations to writable tmpdirs when unset."""
+    os.environ.setdefault("HF_DATASETS_CACHE", "/tmp/hf-cache")
+    os.environ.setdefault("HF_HOME", "/tmp/hf-home")
+
+
 def _load_hf_dataset(data_dir: Path, split: str) -> BenchmarkDataset:
     """Load from HF Arrow format saved via datasets.save_to_disk()."""
-    hf_cache = os.environ.get("HF_DATASETS_CACHE", "/tmp/hf-cache")
-    os.environ.setdefault("HF_DATASETS_CACHE", hf_cache)
-    os.environ.setdefault("HF_HOME", os.environ.get("HF_HOME", "/tmp/hf-home"))
-
+    _ensure_hf_cache_env()
     from datasets import load_from_disk
 
     ds_dict = load_from_disk(str(data_dir))
@@ -169,8 +239,40 @@ def _load_hf_dataset(data_dir: Path, split: str) -> BenchmarkDataset:
         msg = f"Split '{split}' not found. Available: {available}"
         raise ValueError(msg)
 
-    ds = ds_dict[split]
+    return _benchmark_from_hf_split(ds_dict[split])
 
+
+def _load_hf_hub_dataset(repo: str, split: str) -> BenchmarkDataset:
+    """Load a split from the HuggingFace Hub.
+
+    Requires a valid HF token for private repos. Set via ``hf auth login``
+    or the ``HF_TOKEN`` / ``HUGGING_FACE_HUB_TOKEN`` env var.
+    """
+    _ensure_hf_cache_env()
+    try:
+        from datasets import load_dataset as hf_load_dataset
+    except ImportError as exc:  # pragma: no cover - import guard
+        msg = (
+            "The 'datasets' package is required to load from the HuggingFace Hub. "
+            "Install it via 'pip install datasets' or use --data-dir to load a local dataset."
+        )
+        raise ImportError(msg) from exc
+
+    try:
+        ds = hf_load_dataset(repo, split=split)
+    except Exception as exc:
+        msg = (
+            f"Failed to load benchmark from HuggingFace Hub repo {repo!r} (split={split!r}). "
+            f"The dataset may be private — run 'hf auth login' or set HF_TOKEN. "
+            f"Alternatively pass --data-dir to use a local copy. Original error: {exc}"
+        )
+        raise FileNotFoundError(msg) from exc
+
+    return _benchmark_from_hf_split(ds)
+
+
+def _benchmark_from_hf_split(ds) -> BenchmarkDataset:
+    """Convert a HuggingFace ``Dataset`` split into a ``BenchmarkDataset``."""
     documents = []
     annotations = {}
 
@@ -187,8 +289,10 @@ def _load_hf_dataset(data_dir: Path, split: str) -> BenchmarkDataset:
             )
         )
 
-        cit_data = json.loads(row.get("citations", "[]"))
-        rel_data = json.loads(row.get("relations", "[]"))
+        cit_raw = row.get("citations", "[]")
+        rel_raw = row.get("relations", "[]")
+        cit_data = json.loads(cit_raw) if isinstance(cit_raw, str) else (cit_raw or [])
+        rel_data = json.loads(rel_raw) if isinstance(rel_raw, str) else (rel_raw or [])
 
         citations = [_parse_citation(c) for c in cit_data]
         rels = [_parse_relation(r) for r in rel_data]

--- a/benchmarks/diagnose.py
+++ b/benchmarks/diagnose.py
@@ -21,8 +21,8 @@ from benchmarks.datasets import load_dataset
 from refex.extractor import RefExtractor
 
 
-def diagnose(data_dir=None, split="validation", limit=None):
-    dataset = load_dataset(data_dir, split=split)
+def diagnose(data_dir=None, split="validation", limit=None, hf_repo=None):
+    dataset = load_dataset(data_dir, split=split, hf_repo=hf_repo)
     extractor = RefExtractor()
 
     # Counters
@@ -185,10 +185,17 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--data-dir", type=Path, default=None)
     parser.add_argument(
+        "--hf-repo",
+        type=str,
+        default=None,
+        metavar="REPO",
+        help="HuggingFace Hub repo id for the dataset fallback (default: $BENCH_HF_REPO)",
+    )
+    parser.add_argument(
         "--split",
         default="validation",
         help="Split to analyze (default: validation; avoid test for development)",
     )
     parser.add_argument("--limit", type=int, default=None)
     args = parser.parse_args()
-    diagnose(args.data_dir, args.split, args.limit)
+    diagnose(args.data_dir, args.split, args.limit, hf_repo=args.hf_repo)

--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from benchmarks.adapter import refmarkers_to_citations
 from benchmarks.datasets import Citation as BenchmarkCitation
 from benchmarks.datasets import Relation as BenchmarkRelation
-from benchmarks.datasets import get_data_dir, load_dataset
+from benchmarks.datasets import get_data_dir, get_hf_repo, load_dataset
 from benchmarks.metrics import BenchmarkResult, score_document, score_relations
 
 logging.basicConfig(
@@ -188,6 +188,7 @@ def run_benchmark(
     engine: str = "regex",
     profile: bool = False,
     profile_output: Path | None = None,
+    hf_repo: str | None = None,
 ) -> tuple[BenchmarkResult, dict]:
     """Run the full benchmark pipeline.
 
@@ -209,7 +210,7 @@ def run_benchmark(
         (BenchmarkResult, timing_stats) tuple.
     """
     t_load_start = time.perf_counter()
-    dataset = load_dataset(data_dir, split=split)
+    dataset = load_dataset(data_dir, split=split, hf_repo=hf_repo)
     t_load = time.perf_counter() - t_load_start
 
     t_init_start = time.perf_counter()
@@ -389,7 +390,20 @@ def main() -> None:
         "--data-dir",
         type=Path,
         default=None,
-        help=f"Path to HF dataset or JSONL directory (default: {get_data_dir()})",
+        help=(
+            f"Path to HF dataset or JSONL directory. If omitted, tries "
+            f"{get_data_dir()} and falls back to the HuggingFace Hub repo."
+        ),
+    )
+    parser.add_argument(
+        "--hf-repo",
+        type=str,
+        default=None,
+        metavar="REPO",
+        help=(
+            "HuggingFace Hub repo id for the dataset fallback "
+            "(default: $BENCH_HF_REPO or openlegaldata/german-legal-references-benchmark)."
+        ),
     )
     parser.add_argument(
         "-s",
@@ -449,7 +463,9 @@ def main() -> None:
     if args.verbose:
         logging.getLogger().setLevel(logging.INFO)
 
-    data_dir = args.data_dir or get_data_dir()
+    # Pass through args.data_dir verbatim so the loader can decide between
+    # local and HF Hub fallback based on whether the user supplied --data-dir.
+    data_dir = args.data_dir
 
     result, timing = run_benchmark(
         data_dir=data_dir,
@@ -458,17 +474,20 @@ def main() -> None:
         engine=args.engine,
         profile=args.profile,
         profile_output=args.profile_output,
+        hf_repo=args.hf_repo,
     )
+
+    resolved_source = str(data_dir) if data_dir is not None else f"hf:{args.hf_repo or get_hf_repo()}"
 
     if args.json:
         out = result.to_dict()
         out["timing"] = timing
         out["split"] = args.split
         out["engine"] = args.engine
-        out["data_dir"] = str(data_dir)
+        out["data_dir"] = resolved_source
         text = json.dumps(out, indent=2, ensure_ascii=False) + "\n"
     else:
-        text = format_summary(result, timing, args.split, data_dir, args.engine) + "\n"
+        text = format_summary(result, timing, args.split, resolved_source, args.engine) + "\n"
 
     if args.output:
         args.output.write_text(text, encoding="utf-8")

--- a/benchmarks/validate.py
+++ b/benchmarks/validate.py
@@ -18,7 +18,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from benchmarks.datasets import BenchmarkDataset, get_data_dir, load_dataset
+from benchmarks.datasets import BenchmarkDataset, get_data_dir, get_hf_repo, load_dataset
 
 VALID_CITATION_TYPES = {"law", "case"}
 VALID_CITATION_KINDS = {"full", "short", "id", "ibid", "supra", "aao", "ebenda"}
@@ -42,9 +42,9 @@ VALID_STRUCTURE_KEYS = {
 }
 
 
-def validate_dataset(data_dir: Path, split: str = "test") -> list[str]:
+def validate_dataset(data_dir: Path | None, split: str = "test", hf_repo: str | None = None) -> list[str]:
     """Run all checks, return list of error strings. Empty = all pass."""
-    dataset = load_dataset(data_dir, split=split)
+    dataset = load_dataset(data_dir, split=split, hf_repo=hf_repo)
 
     errors: list[str] = []
     warnings: list[str] = []
@@ -198,7 +198,20 @@ def main() -> None:
         "--data-dir",
         type=Path,
         default=None,
-        help=f"Path to HF dataset or JSONL directory (default: {get_data_dir()})",
+        help=(
+            f"Path to HF dataset or JSONL directory. If omitted, tries "
+            f"{get_data_dir()} and falls back to the HuggingFace Hub repo."
+        ),
+    )
+    parser.add_argument(
+        "--hf-repo",
+        type=str,
+        default=None,
+        metavar="REPO",
+        help=(
+            "HuggingFace Hub repo id for the dataset fallback "
+            "(default: $BENCH_HF_REPO or openlegaldata/german-legal-references-benchmark)."
+        ),
     )
     parser.add_argument(
         "-s",
@@ -209,13 +222,12 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    data_dir = args.data_dir or get_data_dir()
-
-    print(f"Validating dataset: {data_dir} (split: {args.split})")
+    source_label = str(args.data_dir) if args.data_dir is not None else f"hf:{args.hf_repo or get_hf_repo()}"
+    print(f"Validating dataset: {source_label} (split: {args.split})")
     print()
 
     try:
-        errors = validate_dataset(data_dir, split=args.split)
+        errors = validate_dataset(args.data_dir, split=args.split, hf_repo=args.hf_repo)
     except FileNotFoundError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/tests/test_dataset_loading.py
+++ b/tests/test_dataset_loading.py
@@ -1,0 +1,174 @@
+"""Tests for benchmark dataset loading: local + HuggingFace Hub fallback."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from benchmarks import datasets as datasets_mod
+from benchmarks.datasets import (
+    _DEFAULT_HF_REPO,
+    BenchmarkDataset,
+    get_hf_repo,
+    load_dataset,
+)
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _make_jsonl_dataset(root: Path, split: str = "test") -> None:
+    split_dir_map = {"train": "train", "validation": "dev", "test": "test"}
+    split_dir = root / split_dir_map[split]
+    _write_jsonl(
+        split_dir / "documents.jsonl",
+        [
+            {
+                "doc_id": "doc1",
+                "text": "Hello world",
+                "court": "BGH",
+                "decision_date": "2024-01-01",
+                "decision_type": "Urteil",
+            }
+        ],
+    )
+    _write_jsonl(
+        split_dir / "annotations.jsonl",
+        [
+            {
+                "doc_id": "doc1",
+                "citations": [
+                    {
+                        "id": "c_001",
+                        "type": "law",
+                        "kind": "full",
+                        "span": {"start": 0, "end": 5, "text": "Hello"},
+                    }
+                ],
+                "relations": [],
+            }
+        ],
+    )
+
+
+def test_get_hf_repo_defaults_to_openlegaldata():
+    with patch.dict("os.environ", {}, clear=False):
+        # Strip env to be safe (BENCH_HF_REPO must NOT be set for this assertion).
+        import os
+
+        os.environ.pop("BENCH_HF_REPO", None)
+        assert get_hf_repo() == _DEFAULT_HF_REPO
+
+
+def test_get_hf_repo_respects_env(monkeypatch):
+    monkeypatch.setenv("BENCH_HF_REPO", "someorg/custom-bench")
+    assert get_hf_repo() == "someorg/custom-bench"
+
+
+def test_load_dataset_uses_local_when_present(tmp_path):
+    _make_jsonl_dataset(tmp_path, split="test")
+    ds = load_dataset(tmp_path, split="test")
+    assert isinstance(ds, BenchmarkDataset)
+    assert ds.doc_ids == ["doc1"]
+    assert ds.documents[0].court == "BGH"
+
+
+def test_load_dataset_explicit_missing_path_raises(tmp_path):
+    """Explicit --data-dir that doesn't exist must NOT silently go to HF Hub."""
+    missing = tmp_path / "nope"
+    with pytest.raises(FileNotFoundError, match="explicit"):
+        load_dataset(missing, split="test")
+
+
+def test_load_dataset_falls_back_to_hub_when_default_missing(monkeypatch, tmp_path):
+    """When --data-dir is omitted and the default doesn't exist, fall back to HF."""
+    monkeypatch.setenv("BENCH_DATA_DIR", str(tmp_path / "absent"))
+    monkeypatch.setenv("BENCH_HF_REPO", "fakeorg/fake-benchmark")
+
+    captured: dict[str, object] = {}
+
+    def fake_load(repo, split):
+        captured["repo"] = repo
+        captured["split"] = split
+        return [
+            {
+                "doc_id": "hub-doc-1",
+                "text": "from hub",
+                "court": "BVerfG",
+                "decision_date": "2025-01-01",
+                "decision_type": "Beschluss",
+                "citations": "[]",
+                "relations": "[]",
+            }
+        ]
+
+    # Inject a tiny stub for the 'datasets' module so we don't depend on it.
+    fake_module = type(sys)("datasets")
+    fake_module.load_dataset = fake_load  # type: ignore[attr-defined]
+    fake_module.load_from_disk = lambda path: {}  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "datasets", fake_module)
+
+    ds = load_dataset(data_dir=None, split="validation")
+
+    assert captured["repo"] == "fakeorg/fake-benchmark"
+    assert captured["split"] == "validation"
+    assert ds.doc_ids == ["hub-doc-1"]
+    assert ds.documents[0].court == "BVerfG"
+
+
+def test_load_dataset_hub_repo_arg_overrides_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("BENCH_DATA_DIR", str(tmp_path / "absent"))
+    monkeypatch.setenv("BENCH_HF_REPO", "fromenv/repo")
+
+    captured: dict[str, object] = {}
+
+    def fake_load(repo, split):
+        captured["repo"] = repo
+        return []
+
+    fake_module = type(sys)("datasets")
+    fake_module.load_dataset = fake_load  # type: ignore[attr-defined]
+    fake_module.load_from_disk = lambda path: {}  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "datasets", fake_module)
+
+    load_dataset(data_dir=None, split="test", hf_repo="explicit/override")
+
+    assert captured["repo"] == "explicit/override"
+
+
+def test_load_dataset_hub_failure_surfaces_helpful_error(monkeypatch, tmp_path):
+    monkeypatch.setenv("BENCH_DATA_DIR", str(tmp_path / "absent"))
+
+    def fake_load(repo, split):
+        raise RuntimeError("403 Forbidden")
+
+    fake_module = type(sys)("datasets")
+    fake_module.load_dataset = fake_load  # type: ignore[attr-defined]
+    fake_module.load_from_disk = lambda path: {}  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "datasets", fake_module)
+
+    with pytest.raises(FileNotFoundError) as exc_info:
+        load_dataset(data_dir=None, split="test")
+
+    msg = str(exc_info.value)
+    assert "hf auth login" in msg.lower() or "hf_token" in msg.lower()
+    assert "403" in msg
+
+
+def test_local_dataset_exists_helper(tmp_path):
+    assert not datasets_mod._local_dataset_exists(tmp_path / "absent")
+
+    _make_jsonl_dataset(tmp_path / "with_jsonl", split="test")
+    assert datasets_mod._local_dataset_exists(tmp_path / "with_jsonl")
+
+    hf_marker = tmp_path / "with_hf"
+    hf_marker.mkdir()
+    (hf_marker / "dataset_dict.json").write_text("{}", encoding="utf-8")
+    assert datasets_mod._local_dataset_exists(hf_marker)


### PR DESCRIPTION
## Summary

The benchmark loader resolves the dataset path from `--data-dir` or `BENCH_DATA_DIR` and supports two on-disk formats (HF Arrow + JSONL). If neither path resolves, the run errors out — which forces every contributor to clone the sibling benchmark repo locally before they can run `make bench`.

This PR adds a third resolution step: when no `--data-dir` is given and the default local path doesn't exist, fall back to `datasets.load_dataset(repo, split=...)` against the HuggingFace Hub. Repo id is configurable via `--hf-repo` or `BENCH_HF_REPO` (default: `openlegaldata/german-legal-references-benchmark`, private).

## Behaviour

| Situation | Result |
|---|---|
| `--data-dir /existing/path` | Use local (unchanged) |
| `--data-dir /missing/path` | Raise — don't silently go to Hub |
| No `--data-dir`, default local exists | Use local (unchanged) |
| No `--data-dir`, default local missing | Fall back to HF Hub via `load_dataset(repo)` |
| Hub call fails (auth, network, etc.) | Surface `hf auth login` / `HF_TOKEN` hint |

## Changes

- `benchmarks/datasets.py`: BENCH_HF_REPO env, get_hf_repo(), _load_hf_hub_dataset(), shared _benchmark_from_hf_split() conversion, new hf_repo arg on load_dataset
- `benchmarks/run.py`, `validate.py`, `diagnose.py`: add --hf-repo flag, stop pre-resolving data_dir
- `tests/test_dataset_loading.py`: 8 tests using sys.modules stub for `datasets`

## Test plan

- [x] `make lint` passes
- [x] `make test` — 358 tests pass, 4 deselected (no regressions)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)